### PR TITLE
Update ktimetracker version to 6.0.0 and more

### DIFF
--- a/appdata.patch
+++ b/appdata.patch
@@ -4,46 +4,63 @@ Date: Sat, 21 May 2022 19:37:42 +0000
 Subject: [PATCH 1/2] Add Open Age Rating
 
 ---
- org.kde.ktimetracker.appdata.xml | 1 +
- 1 file changed, 1 insertion(+)
+ org.kde.ktimetracker.appdata.xml | 23 ++++++++++++++---------
+ 1 file changed, 14 insertions(+), 9 deletions(-)
 
 diff --git a/org.kde.ktimetracker.appdata.xml b/org.kde.ktimetracker.appdata.xml
-index 7ab3eb7..fc19d67 100644
+index fadfb7d..d251ede 100644
 --- a/org.kde.ktimetracker.appdata.xml
 +++ b/org.kde.ktimetracker.appdata.xml
-@@ -135,6 +135,7 @@
-     <p xml:lang="x-test">xxWith KTimeTracker, you can organize a broken-down project as subtasks with unlimited nesting. The standard keyboard and mouse shortcuts are simple and make the tool really comfortable and intuitive to use.xx</p>
-     <p xml:lang="zh-CN">通过 KTimeTracker，您可以将零碎的项目整理成无限套的小任务。简易标准的键鼠快捷键使本工具十分舒适且直观使用。</p>
-   </description>
-+  <content_rating type="oars-1.1" />
-   <url type="bugtracker">https://bugs.kde.org/enter_bug.cgi?format=guided&amp;product=ktimetracker</url>
-   <screenshots>
-     <screenshot type="default">
--- 
-GitLab
-
-
-From 5cf32835eb7b969a797ae6892d3b10a32836e098 Mon Sep 17 00:00:00 2001
-From: =?UTF-8?q?Matthias=20Mail=C3=A4nder?= <matthias@mailaender.name>
-Date: Sat, 21 May 2022 19:38:50 +0000
-Subject: [PATCH 2/2] Add homepage
-
----
- org.kde.ktimetracker.appdata.xml | 1 +
- 1 file changed, 1 insertion(+)
-
-diff --git a/org.kde.ktimetracker.appdata.xml b/org.kde.ktimetracker.appdata.xml
-index fc19d67..8b68a4d 100644
---- a/org.kde.ktimetracker.appdata.xml
-+++ b/org.kde.ktimetracker.appdata.xml
-@@ -136,6 +136,7 @@
-     <p xml:lang="zh-CN">通过 KTimeTracker，您可以将零碎的项目整理成无限套的小任务。简易标准的键鼠快捷键使本工具十分舒适且直观使用。</p>
-   </description>
-   <content_rating type="oars-1.1" />
+@@ -5,14 +5,26 @@ SPDX-FileCopyrightText: 2022 Matthias Mailänder <matthias@mailaender.name>
+ 
+ SPDX-License-Identifier: GPL-2.0-or-later
+ -->
+-<component type="desktop">
+-  <id>org.kde.ktimetracker.desktop</id>
++<component type="desktop-application">
++  <id>org.kde.ktimetracker</id>
+   <metadata_license>CC0-1.0</metadata_license>
+   <project_license>GPL-2.0</project_license>
+   <developer id="org.kde">
+     <name translate="no">KDE</name>
+   </developer>
+   <launchable type="desktop-id">org.kde.ktimetracker.desktop</launchable>
++  <content_rating type="oars-1.1"/>
 +  <url type="homepage">https://apps.kde.org/ktimetracker</url>
-   <url type="bugtracker">https://bugs.kde.org/enter_bug.cgi?format=guided&amp;product=ktimetracker</url>
++  <url type="bugtracker">https://bugs.kde.org/enter_bug.cgi?format=guided&amp;product=ktimetracker</url>
++  <url type="vcs-browser">https://invent.kde.org/pim/ktimetracker</url>
++  <project_group>KDE</project_group>
++  <provides>
++    <binary>ktimetracker</binary>
++    <id>org.kde.ktimetracker.desktop</id>
++  </provides>
++  <replaces>
++    <id>org.kde.ktimetracker.desktop</id>
++  </replaces>
+   <name>KTimeTracker</name>
+   <name xml:lang="ar">متعقب الوقت</name>
+   <name xml:lang="ast">KTimeTracker</name>
+@@ -194,9 +206,6 @@ SPDX-License-Identifier: GPL-2.0-or-later
+     <p xml:lang="zh-CN">通过 KTimeTracker，您可以将零碎的项目整理成无限套的小任务。简易标准的键鼠快捷键使本工具十分舒适且直观使用。</p>
+     <p xml:lang="zh-TW">利用 KTimeTracker，您可以將專案分為子工作來管理，子工作之下也能有更多子工作，沒有層數限制。標準提供的鍵盤與滑鼠快捷鍵簡潔易懂，讓此工具使用起來直覺且順暢。</p>
+   </description>
+-  <content_rating type="oars-1.1"/>
+-  <url type="homepage">https://apps.kde.org/ktimetracker</url>
+-  <url type="bugtracker">https://bugs.kde.org/enter_bug.cgi?format=guided&amp;product=ktimetracker</url>
    <screenshots>
      <screenshot type="default">
--- 
-GitLab
+       <caption>KTimeTracker</caption>
+@@ -240,10 +249,6 @@ SPDX-License-Identifier: GPL-2.0-or-later
+       <image>https://cdn.kde.org/screenshots/ktimetracker/ktimetracker.png</image>
+     </screenshot>
+   </screenshots>
+-  <project_group>KDE</project_group>
+-  <provides>
+-    <binary>ktimetracker</binary>
+-  </provides>
+   <releases>
+     <release version="6.0.0" date="2025-06-17"/>
+     <release version="5.0.1" date="2019-12-21">
+--
+libgit2 1.7.2
 

--- a/org.kde.ktimetracker.json
+++ b/org.kde.ktimetracker.json
@@ -1,7 +1,7 @@
 {
   "app-id": "org.kde.ktimetracker",
   "runtime": "org.kde.Platform",
-  "runtime-version": "5.15-23.08",
+  "runtime-version": "6.10",
   "sdk": "org.kde.Sdk",
   "command": "ktimetracker",
   "rename-icon": "ktimetracker",
@@ -12,15 +12,23 @@
     "--socket=fallback-x11",
     "--talk-name=org.kde.StatusNotifierWatcher"
   ],
+  "cleanup": [
+      "/share/doc",
+      "/share/man"
+  ],
   "modules": [
     {
       "name": "ktimetracker",
       "buildsystem": "cmake-ninja",
+      "post-install": [
+          "find /app/share/icons/hicolor -type f -not -path \"*scalable*\" -not -path \"*actions*\" -name \"*.svg\" -delete",
+          "install -Dm644 icons/breeze/48-apps-ktimetracker.svg /app/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.svg"
+      ],
       "sources": [
         {
           "type": "archive",
-          "url": "https://download.kde.org/stable/ktimetracker/5.0.1/src/ktimetracker-5.0.1.tar.xz",
-          "sha256": "02e8620164357e594e135e20d8efd3987cc9c31a817c25e5555914e0971be64a"
+          "url": "https://download.kde.org/unstable/ktimetracker/ktimetracker-6.0.0.tar.xz",
+          "sha256": "50597e689f08efdaa79439a0aa9886ce47aaddb5a6018a57ffeea6cb7f666e69"
         },
         {
           "type": "patch",


### PR DESCRIPTION
- Update ktimetracker version to 6.0.0
- Update runtime to 6.10
- Fix appdata paper cuts
- Add a workaround for non-png-icon-in-hicolor-size-folder lint error
